### PR TITLE
Add loan history API endpoint

### DIFF
--- a/app/api/endpoints/loan_history.py
+++ b/app/api/endpoints/loan_history.py
@@ -1,0 +1,104 @@
+# /app/api/endpoints/loan_history.py
+"""
+Loan history API endpoint - get Quotient loan data for Farcaster users.
+"""
+import logging
+from fastapi import APIRouter, HTTPException
+from app.models.loan_models import LoanHistoryRequest, LoanHistoryResponse, Loan
+from app.db.postgres import execute_postgres_query
+from app.config import REPUTATION_PASS
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.post(
+    "/loan-history",
+    summary="Get Quotient loan history for Farcaster users",
+    description="Retrieves loan history including status, principal, repayments for up to 100 FIDs.",
+    response_model=LoanHistoryResponse,
+    responses={
+        200: {"description": "Successfully retrieved loan history", "model": LoanHistoryResponse},
+        401: {"description": "Unauthorized - Invalid API key"},
+        404: {"description": "No loans found for the provided FIDs"},
+        500: {"description": "Internal Server Error"}
+    }
+)
+async def get_loan_history(request: LoanHistoryRequest) -> Dict[str, Any]:
+    """
+    Get loan history for Farcaster users.
+
+    - Requires valid API key
+    - Accepts single fid or list of fids (max 100)
+    - Returns all loans with status, amounts, and timestamps
+    """
+    if request.api_key != REPUTATION_PASS:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    # Build fid list
+    fids = []
+    if request.fid:
+        fids = [request.fid]
+    elif request.fids:
+        fids = request.fids[:100]  # Limit to 100
+    else:
+        raise HTTPException(status_code=400, detail="Must provide fid or fids")
+
+    logger.info(f"POST /loan-history - Looking up loans for {len(fids)} FIDs")
+
+    try:
+        query = """
+        SELECT
+            loan_id,
+            fid,
+            borrower,
+            principal_usdc,
+            total_repaid_usdc,
+            remaining_usdc,
+            loan_status,
+            originated_at,
+            last_repayment_at,
+            fully_repaid_at,
+            repayment_count
+        FROM quotient.loan_history
+        WHERE fid = ANY(:fids)
+        ORDER BY originated_at DESC
+        """
+
+        results = execute_postgres_query(query, {"fids": fids})
+
+        if not results:
+            return {
+                "loans": [],
+                "count": 0
+            }
+
+        loans = []
+        for row in results:
+            loans.append(Loan(
+                loan_id=row["loan_id"],
+                fid=int(row["fid"]),
+                borrower=row["borrower"],
+                principal_usdc=float(row["principal_usdc"]),
+                total_repaid_usdc=float(row["total_repaid_usdc"]),
+                remaining_usdc=float(row["remaining_usdc"]),
+                loan_status=row["loan_status"],
+                originated_at=str(row["originated_at"]) if row["originated_at"] else None,
+                last_repayment_at=str(row["last_repayment_at"]) if row["last_repayment_at"] else None,
+                fully_repaid_at=str(row["fully_repaid_at"]) if row["fully_repaid_at"] else None,
+                repayment_count=row["repayment_count"]
+            ))
+
+        logger.info(f"Found {len(loans)} loans for requested FIDs")
+
+        return {
+            "loans": loans,
+            "count": len(loans)
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching loan history: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -4,15 +4,16 @@ API router that includes all endpoint routers.
 """
 from fastapi import APIRouter
 from app.api.endpoints import (
-    tokens, 
-    reputation, 
-    farcaster_users, 
+    tokens,
+    reputation,
+    farcaster_users,
     farcaster_connections,
     farcaster_connections_all,
-    clankers, 
-    allowlist, 
+    clankers,
+    allowlist,
     leaderboard,
-    wallet_lookup
+    wallet_lookup,
+    loan_history
 )
 
 # Create main router
@@ -28,3 +29,4 @@ router.include_router(clankers.router, tags=["Clankers"])
 router.include_router(allowlist.router, tags=["Allowlist"])
 router.include_router(leaderboard.router, tags=["Leaderboards"])
 router.include_router(wallet_lookup.router, tags=["Wallet Lookup"])
+router.include_router(loan_history.router, tags=["Loans"])

--- a/app/models/loan_models.py
+++ b/app/models/loan_models.py
@@ -1,0 +1,35 @@
+# /app/models/loan_models.py
+"""
+Pydantic models for loan history endpoint.
+"""
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from datetime import datetime
+
+
+class LoanHistoryRequest(BaseModel):
+    """Request model for loan history lookup."""
+    fid: Optional[int] = Field(None, description="Farcaster ID to look up loans for")
+    fids: Optional[List[int]] = Field(None, description="List of Farcaster IDs (max 100)")
+    api_key: str = Field(..., description="API key for authentication")
+
+
+class Loan(BaseModel):
+    """Individual loan record."""
+    loan_id: str = Field(..., description="Unique loan identifier (origin tx hash)")
+    fid: int = Field(..., description="Farcaster ID of borrower")
+    borrower: str = Field(..., description="Ethereum address of borrower")
+    principal_usdc: float = Field(..., description="Original loan amount in USDC")
+    total_repaid_usdc: float = Field(..., description="Total amount repaid in USDC")
+    remaining_usdc: float = Field(..., description="Remaining balance in USDC")
+    loan_status: str = Field(..., description="FULLY_REPAID, ACTIVE_REPAYING, or ACTIVE_NO_PAYMENT")
+    originated_at: Optional[str] = Field(None, description="Loan origination timestamp")
+    last_repayment_at: Optional[str] = Field(None, description="Last repayment timestamp")
+    fully_repaid_at: Optional[str] = Field(None, description="Full repayment timestamp")
+    repayment_count: int = Field(..., description="Number of repayments made")
+
+
+class LoanHistoryResponse(BaseModel):
+    """Response model for loan history endpoint."""
+    loans: List[Loan] = Field(..., description="List of loans")
+    count: int = Field(..., description="Number of loans returned")


### PR DESCRIPTION
POST /v1/loan-history - returns Quotient loan data for Farcaster users. Queries quotient.loan_history table populated by the pipelines repo.